### PR TITLE
Fixed inconsistent tabular output csv logging

### DIFF
--- a/src/dowel/simple_outputs.py
+++ b/src/dowel/simple_outputs.py
@@ -56,7 +56,7 @@ class FileOutput(LogOutput, metaclass=abc.ABCMeta):
     :param mode: File open mode ('a', 'w', etc).
     """
 
-    def __init__(self, file_name, mode='w'):
+    def __init__(self, file_name, mode='w+'):
         mkdir_p(os.path.dirname(file_name))
         # Open the log file in child class
         self._log_file = open(file_name, mode)


### PR DESCRIPTION
I added support for new keys and missing keys in and removed warnings from CsvOutput. I updated the test cases to not use warnings and added 3 new tests for the new functionality. I'm pretty sure the new key / missing key functionality is robust. I don't think removing the warnings broke anything (all tests pass), but probably worth investigating before merging